### PR TITLE
feat: add configurable route for `/env` endpoint

### DIFF
--- a/examples/stdlib/main.go
+++ b/examples/stdlib/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	opts := systatus.SystatusOptions{Prefix: "/dev"}
+	opts := systatus.SystatusOptions{Prefix: "/dev", ExposeEnv: true}
 	systatus.Enable(opts)
 	fmt.Println("Starting server on :3333")
 	if err := http.ListenAndServe(":3333", nil); err != nil {

--- a/systatus.go
+++ b/systatus.go
@@ -11,7 +11,8 @@ import (
 )
 
 type SystatusOptions struct {
-	Prefix string
+	Prefix    string
+	ExposeEnv bool
 }
 
 type HealthResponse struct{}
@@ -31,7 +32,10 @@ func Enable(opts SystatusOptions) {
 	http.HandleFunc(fmt.Sprintf("%s/cpu", opts.Prefix), handleCPU)
 	http.HandleFunc(fmt.Sprintf("%s/mem", opts.Prefix), handleMem)
 	http.HandleFunc(fmt.Sprintf("%s/disk", opts.Prefix), handleDisk)
-	http.HandleFunc(fmt.Sprintf("%s/env", opts.Prefix), handleEnv)
+
+	if opts.ExposeEnv {
+		http.HandleFunc(fmt.Sprintf("%s/env", opts.Prefix), handleEnv)
+	}
 }
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This change resolves #4  by adding a field `ExposeEnv` to enable/disable the `/env` endpoint.