### PR TITLE
feat: add custom health check function

### DIFF
--- a/examples/stdlib/main.go
+++ b/examples/stdlib/main.go
@@ -7,8 +7,14 @@ import (
 	"github.com/gdegiorgio/systatus"
 )
 
+func customHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Add("Content-Type", "application/json")
+	fmt.Fprint(w, `{"status":"application is healthy"}`)
+}
+
 func main() {
-	opts := systatus.SystatusOptions{Prefix: "/dev", ExposeEnv: true}
+	opts := systatus.SystatusOptions{Prefix: "/dev", ExposeEnv: true, Healthcheck: customHealthCheck}
 	systatus.Enable(opts)
 	fmt.Println("Starting server on :3333")
 	if err := http.ListenAndServe(":3333", nil); err != nil {

--- a/systatus.go
+++ b/systatus.go
@@ -11,8 +11,9 @@ import (
 )
 
 type SystatusOptions struct {
-	Prefix    string
-	ExposeEnv bool
+	Prefix      string
+	ExposeEnv   bool
+	Healthcheck func(w http.ResponseWriter, r *http.Request)
 }
 
 type HealthResponse struct{}
@@ -27,7 +28,12 @@ type EnvResponse struct {
 }
 
 func Enable(opts SystatusOptions) {
-	http.HandleFunc(fmt.Sprintf("%s/health", opts.Prefix), handleHealth)
+	if opts.Healthcheck == nil {
+		http.HandleFunc(fmt.Sprintf("%s/health", opts.Prefix), handleHealth)
+	} else {
+		http.HandleFunc(fmt.Sprintf("%s/health", opts.Prefix), opts.Healthcheck)
+	}
+
 	http.HandleFunc(fmt.Sprintf("%s/uptime", opts.Prefix), handleUptime)
 	http.HandleFunc(fmt.Sprintf("%s/cpu", opts.Prefix), handleCPU)
 	http.HandleFunc(fmt.Sprintf("%s/mem", opts.Prefix), handleMem)


### PR DESCRIPTION
This change resolves #5  by adding support for a custom user-defined health check function for the `/health` endpoint.