### PR TITLE
fix: make handler methods private

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -7,6 +7,6 @@ type CPUHandlerOpts struct {
 }
 type CPUResponse struct{}
 
-func HandleCPU(opts CPUHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
+func handleCPU(opts CPUHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {}
 }

--- a/disk.go
+++ b/disk.go
@@ -7,6 +7,6 @@ type DiskHandlerOpts struct {
 }
 type DiskResponse struct{}
 
-func HandleDisk(opts DiskHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
+func handleDisk(opts DiskHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {}
 }

--- a/env.go
+++ b/env.go
@@ -15,7 +15,7 @@ type EnvResponse struct {
 	Env map[string]string `json:"env"`
 }
 
-func HandleEnv(opts EnvHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
+func handleEnv(opts EnvHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		res := EnvResponse{}
 		env := os.Environ()

--- a/health.go
+++ b/health.go
@@ -16,7 +16,7 @@ type HealthResponse struct {
 	Status string `json:"status"`
 }
 
-func HandleHealth(opts HealthHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
+func handleHealth(opts HealthHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
 	if opts.Healthcheck != nil {
 		log.Debug().Msg("Found a custom healthcheck")
 		return opts.Healthcheck

--- a/systatus.go
+++ b/systatus.go
@@ -31,13 +31,13 @@ func Enable(opts SystatusOptions) {
 	if opts.Mux != nil {
 		mux = opts.Mux
 	}
-	mux.HandleFunc(fmt.Sprintf("%s/health", opts.Prefix), useMiddlewares(HandleHealth(opts.HealthHandlerOpts), opts.CPUHandlerOpts.Middlewares))
-	mux.HandleFunc(fmt.Sprintf("%s/uptime", opts.Prefix), useMiddlewares(HandleUptime(opts.UptimeHandlerOpts), opts.UptimeHandlerOpts.Middlewares))
-	mux.HandleFunc(fmt.Sprintf("%s/cpu", opts.Prefix), useMiddlewares(HandleCPU(opts.CPUHandlerOpts), opts.CPUHandlerOpts.Middlewares))
+	mux.HandleFunc(fmt.Sprintf("%s/health", opts.Prefix), useMiddlewares(handleHealth(opts.HealthHandlerOpts), opts.CPUHandlerOpts.Middlewares))
+	mux.HandleFunc(fmt.Sprintf("%s/uptime", opts.Prefix), useMiddlewares(handleUptime(opts.UptimeHandlerOpts), opts.UptimeHandlerOpts.Middlewares))
+	mux.HandleFunc(fmt.Sprintf("%s/cpu", opts.Prefix), useMiddlewares(handleCPU(opts.CPUHandlerOpts), opts.CPUHandlerOpts.Middlewares))
 	mux.HandleFunc(fmt.Sprintf("%s/mem", opts.Prefix), useMiddlewares(HandleMem(opts.MemHandlerOpts), opts.MemHandlerOpts.Middlewares))
-	mux.HandleFunc(fmt.Sprintf("%s/disk", opts.Prefix), useMiddlewares(HandleDisk(opts.DiskHandlerOpts), opts.DiskHandlerOpts.Middlewares))
+	mux.HandleFunc(fmt.Sprintf("%s/disk", opts.Prefix), useMiddlewares(handleDisk(opts.DiskHandlerOpts), opts.DiskHandlerOpts.Middlewares))
 
 	if opts.ExposeEnv {
-		mux.HandleFunc(fmt.Sprintf("%s/env", opts.Prefix), useMiddlewares(HandleEnv(opts.EnvHandlerOpts), opts.EnvHandlerOpts.Middlewares))
+		mux.HandleFunc(fmt.Sprintf("%s/env", opts.Prefix), useMiddlewares(handleEnv(opts.EnvHandlerOpts), opts.EnvHandlerOpts.Middlewares))
 	}
 }

--- a/uptime.go
+++ b/uptime.go
@@ -15,7 +15,7 @@ type UptimeResponse struct {
 	Uptime  string `json:"uptime"`
 }
 
-func HandleUptime(opts UptimeHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
+func handleUptime(opts UptimeHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		res := UptimeResponse{}
 		cmdoutput, err := exec.Command("/bin/uptime").Output()


### PR DESCRIPTION


### Description

This PR makes handler methods private and unexported so they do not appear in go doc

### Related Issue

No related issue

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

### Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] I have tested my changes
- [x] I have updated relevant documentation
- [x] I have reviewed my code for potential issues

