### PR TITLE
feat: hide sensitive values in `env`

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -1,1 +1,41 @@
 package systatus
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvSensitiveValues(t *testing.T) {
+	mux := http.NewServeMux()
+
+	opts := SystatusOptions{
+		Prefix:    "",
+		Mux:       mux,
+		ExposeEnv: true,
+		EnvHandlerOpts: EnvHandlerOpts{
+			SensitiveKeys: []string{"PASSWORD"},
+		},
+	}
+
+	os.Setenv("PASSWORD", "CLEARTEXT-PASSWORD")
+
+	Enable(opts)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	res, _ := http.Get(fmt.Sprintf("%s/env", ts.URL))
+	assert.Equal(t, 200, res.StatusCode)
+
+	var r EnvResponse
+	err := json.NewDecoder(res.Body).Decode(&r)
+	assert.NoError(t, err)
+	assert.NotEqual(t, "CLEARTEXT-PASSWORD", r.Env["PASSWORD"])
+	assert.Equal(t, "******************", r.Env["PASSWORD"])
+}

--- a/examples/stdlib/main.go
+++ b/examples/stdlib/main.go
@@ -17,8 +17,12 @@ func customHealthCheck(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	opts := systatus.SystatusOptions{
-		Prefix:    "/dev",
-		ExposeEnv: true,
+		Prefix:       "/dev",
+		ExposeEnv:    true,
+		PrettyLogger: true,
+		EnvHandlerOpts: systatus.EnvHandlerOpts{
+			SensitiveKeys: []string{"PASSWORD"},
+		},
 		HealthHandlerOpts: systatus.HealthHandlerOpts{
 			Middlewares: []func(next http.HandlerFunc) http.HandlerFunc{middleware.Logger},
 			Healthcheck: customHealthCheck,

--- a/systatus.go
+++ b/systatus.go
@@ -3,12 +3,17 @@ package systatus
 import (
 	"fmt"
 	"net/http"
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 type SystatusOptions struct {
 	Mux               *http.ServeMux
 	Prefix            string
 	ExposeEnv         bool
+	PrettyLogger      bool
 	HealthHandlerOpts HealthHandlerOpts
 	CPUHandlerOpts    CPUHandlerOpts
 	EnvHandlerOpts    EnvHandlerOpts
@@ -25,6 +30,10 @@ func useMiddlewares(handler func(w http.ResponseWriter, r *http.Request), middle
 }
 
 func Enable(opts SystatusOptions) {
+
+	if opts.PrettyLogger {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	}
 
 	mux := http.DefaultServeMux
 


### PR DESCRIPTION


### Description

This PR let user customize `/env` response by hiding sensitive values

### Related Issue

Closes #6 

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

### Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] I have tested my changes
- [x] I have updated relevant documentation
- [x] I have reviewed my code for potential issues

