### PR TITLE
feat(uptime): return systime in RFC3339 and uptime in milliseconds; implement win `uptime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ This endpoint is used to report system uptime and current system time.
 Systime	string	The current system time in a human-readable format (e.g., ISO 8601).
 Uptime	string	The server's uptime since it was started, formatted as hh:mm:ss.
 
-| _**Field**_ | **_Type_** | **_Description_**                                                                                    |
-|-------------|------------|------------------------------------------------------------------------------------------------------|
-| `Systime`   | `string`   | The current system time in a human-readable format (e.g., ISO 8601)                                        |
-| `Uptime`    | `string`   | The server's uptime since it was started, formatted as hh:mm:ss.                                             |
+| _**Field**_ | **_Type_** | **_Description_**                                          |
+|-------------|------------|------------------------------------------------------------|
+| `Systime`   | `string`   | The current system time in RFC3339 format                  |
+| `Uptime`    | `float64`  | The server's uptime since it was started, in milliseconds. |
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Uptime	string	The server's uptime since it was started, formatted as hh:mm:ss.
 
 ```json
 {
-  "systime": "2024-11-24T12:34:56Z",
-  "uptime": "01:23:45"
+  "systime": "2024-11-27T20:58:09+01:00",
+  "uptime": 2817580
 }
 ```

--- a/examples/stdlib/main.go
+++ b/examples/stdlib/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -10,9 +11,8 @@ import (
 )
 
 func customHealthCheck(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
 	w.Header().Add("Content-Type", "application/json")
-	fmt.Fprint(w, `{"status":"application is healthy"}`)
+	json.NewEncoder(w).Encode(systatus.HealthResponse{Status: "HEALTHY"})
 }
 
 func main() {

--- a/mem.go
+++ b/mem.go
@@ -27,5 +27,4 @@ func HandleMem(opts MemHandlerOpts) func(w http.ResponseWriter, r *http.Request)
 		w.Header().Add("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(res)
 	}
-
 }

--- a/uptime.go
+++ b/uptime.go
@@ -49,7 +49,10 @@ func handleUptime(opts UptimeHandlerOpts) func(w http.ResponseWriter, r *http.Re
 
 func getWinUptime() (UptimeResponse, error) {
 	log.Warn().Msg("If FastBoot is enabled, uptime on Windows may be tracked incorrectly")
-	cmdoutput, _ := exec.Command("systeminfo | find \"System Boot Time\"").Output()
+	cmdoutput, err := exec.Command("systeminfo | find \"System Boot Time\"").Output()
+	if err != nil {
+		return UptimeResponse{}, err
+	}
 	log.Debug().Msg(string(cmdoutput))
 	return UptimeResponse{}, nil
 }

--- a/uptime.go
+++ b/uptime.go
@@ -64,7 +64,7 @@ func getWinUptime() (UptimeResponse, error) {
 	minutes := strings.Split(splitCmd[4], ":")
 
 	return UptimeResponse{
-		Uptime: formatWinDate(strings.TrimSpace(days[1]), strings.TrimSpace(hours[1]), strings.TrimSpace(minutes[1])),
+		Uptime: formatDate(strings.TrimSpace(days[1]), strings.TrimSpace(hours[1]), strings.TrimSpace(minutes[1])),
 	}, nil
 }
 
@@ -73,14 +73,20 @@ func getUptime() (UptimeResponse, error) {
 	if err != nil {
 		return UptimeResponse{}, err
 	}
-	splitCmd := strings.Split(string(cmdoutput), " ")
+	log.Debug().Msgf("System uptime: %v", strings.Split(string(cmdoutput), " "))
+
+	splitCmd := strings.Split(strings.TrimSpace(string(cmdoutput)), " ")
+
+	systime := strings.TrimSpace(splitCmd[0])
+	uptime := strings.TrimSpace(strings.Split(splitCmd[4], ",")[0])
+
 	return UptimeResponse{
-		Systime: strings.TrimSpace(splitCmd[1]),
-		Uptime:  strings.TrimSpace(strings.Split(splitCmd[4], ",")[0]),
+		Systime: systime,
+		Uptime:  uptime,
 	}, nil
 }
 
-func formatWinDate(d string, h string, m string) string {
+func formatDate(d string, h string, m string) string {
 
 	days, _ := strconv.Atoi(d)
 	hours, _ := strconv.Atoi(h)

--- a/uptime.go
+++ b/uptime.go
@@ -2,7 +2,6 @@ package systatus
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -89,11 +88,8 @@ func getMacOSUptime() (float64, error) {
 	}
 
 	data := strings.TrimSpace(string(output))
-	log.Debug().Msgf("%v", data)
-
 	uptime, err := strconv.ParseFloat(data, 64)
 	if err != nil {
-		fmt.Printf("%w", err)
 		return 0, err
 	}
 	return uptime, nil

--- a/uptime.go
+++ b/uptime.go
@@ -20,8 +20,10 @@ type UptimeResponse struct {
 func handleUptime(opts UptimeHandlerOpts) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 
-		var res UptimeResponse
+		res := UptimeResponse{}
 		var err error
+
+		log.Debug().Msgf("Handling uptime on %s machine", runtime.GOOS)
 
 		if runtime.GOOS == "windows" {
 			res, err = getWinUptime()
@@ -32,32 +34,34 @@ func handleUptime(opts UptimeHandlerOpts) func(w http.ResponseWriter, r *http.Re
 		if err != nil {
 			log.Err(err).Msg("Could not execute uptime on this host")
 			w.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 
-		w.WriteHeader(200)
 		w.Header().Add("Content-Type", "application/json")
 		err = json.NewEncoder(w).Encode(res)
 		if err != nil {
 			log.Err(err).Msg("Failed to encode response")
 			w.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 	}
 }
 
 func getWinUptime() (UptimeResponse, error) {
-	log.Warn().Msg("If FastBoot is enabled, uptime may be tracked incorrectly")
+	log.Warn().Msg("If FastBoot is enabled, uptime on Windows may be tracked incorrectly")
+	cmdoutput, _ := exec.Command("systeminfo | find \"System Boot Time\"").Output()
+	log.Debug().Msg(string(cmdoutput))
 	return UptimeResponse{}, nil
 }
 
 func getUptime() (UptimeResponse, error) {
-	log.Debug().Msg("Handling uptime on unix machine")
 	cmdoutput, err := exec.Command("/usr/bin/uptime").Output()
 	if err != nil {
 		return UptimeResponse{}, err
 	}
 	splitCmd := strings.Split(string(cmdoutput), " ")
 	return UptimeResponse{
-		Systime: strings.TrimSpace(splitCmd[0]),
-		Uptime:  strings.TrimSpace(strings.Split(splitCmd[3], ",")[0]),
+		Systime: strings.TrimSpace(splitCmd[1]),
+		Uptime:  strings.TrimSpace(strings.Split(splitCmd[4], ",")[0]),
 	}, nil
 }


### PR DESCRIPTION

### Description

Implement Windows uptime
Uptime is now in milliseconds.
Systime is now in RFC3339 format.


```json
{
    "systime":"2024-11-27T20:58:09+01:00",
    "uptime":2817580
}
```
### Related Issue

Closes #26 
Fixes #27 

Link to the related issue, if any (e.g., `Fixes #123`).

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactoring

### Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] I have tested my changes
- [x] I have updated relevant documentation
- [x] I have reviewed my code for potential issues

